### PR TITLE
mcf-rcon: Connect to the right server

### DIFF
--- a/mcf-rcon.el
+++ b/mcf-rcon.el
@@ -144,7 +144,7 @@
            :name mcf-rcon--proc-name
            :family mcf-rcon-family
            :buffer mcf-rcon--buffer-name
-           :address mcf-rcon-address
+           :host mcf-rcon-address
            :service mcf-rcon-port
            :noquery t
            :nowait t


### PR DESCRIPTION
* mcf-rcon.el (mcf-rcon--make-network-process): Use :host instead of :address.